### PR TITLE
fix: correct SAM2 serverless deployment

### DIFF
--- a/serverless/pytorch/facebookresearch/sam2/function.yaml
+++ b/serverless/pytorch/facebookresearch/sam2/function.yaml
@@ -40,7 +40,7 @@ spec:
         - kind: RUN
           value: apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/lists/*
         - kind: RUN
-          value: ln -sfdocker compose down -v /usr/bin/python3 /usr/bin/python
+          value: ln -sf /usr/bin/python3 /usr/bin/python
         - kind: RUN
           value: python3 -m pip install --upgrade pip
         - kind: RUN

--- a/serverless/pytorch/facebookresearch/sam2_interactor/function.yaml
+++ b/serverless/pytorch/facebookresearch/sam2_interactor/function.yaml
@@ -30,6 +30,12 @@ spec:
         - kind: ENV
           value: DEBIAN_FRONTEND=noninteractive
         - kind: RUN
+          value: apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+        - kind: WORKDIR
+          value: /opt/nuclio/weights
+        - kind: RUN
+          value: curl -L -o /opt/nuclio/weights/sam2.1_hiera_large.pt https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt
+        - kind: RUN
           value: apt-get update && apt-get install -y python3-pip git build-essential python3-dev && rm -rf /var/lib/apt/lists/*
         - kind: RUN
           value: ln -sf /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
## Summary
- fix python symlink command in SAM2 encoder deployment
- add weight download for SAM2 interactor deployment

## Testing
- `python3 -m py_compile serverless/pytorch/facebookresearch/sam2/model_handler.py serverless/pytorch/facebookresearch/sam2_interactor/model_handler.py`
- `python3 - <<'PY'
import yaml
for path in [
    'serverless/pytorch/facebookresearch/sam2/function.yaml',
    'serverless/pytorch/facebookresearch/sam2_interactor/function.yaml',
]:
    with open(path) as f:
        yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68affa27cbb4833393b92e928003b1b0